### PR TITLE
Update ThingDefs_Buildings.xml

### DIFF
--- a/1.5/Defs/ThingDefs_Buildings.xml
+++ b/1.5/Defs/ThingDefs_Buildings.xml
@@ -203,6 +203,7 @@
 		</inspectorTabs>
 		<comps>
 			<li Class="CompProperties_Refuelable">
+				<consumeFuelOnlyWhenUsed>true</consumeFuelOnlyWhenUsed>
 				<fuelConsumptionRate>10</fuelConsumptionRate>
 				<fuelCapacity>100.0</fuelCapacity>
 				<fuelFilter>


### PR DESCRIPTION
Makes the Chemfuel Crematorium in line with other chemfuel powered work benches in that they only consume fuel when in use.